### PR TITLE
Permit LESSHISTFILE to be defined to "-"

### DIFF
--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -1212,7 +1212,9 @@ histfile_name(void)
 		return (save(name));
 	}
 
-	/* Otherwise, file is in $HOME. */
+	/* Otherwise, file is in $HOME if enabled. */
+	if (*LESSHISTFILE == '\0')
+		return (NULL);
 	home = lgetenv("HOME");
 	if (home == NULL || *home == '\0') {
 		return (NULL);


### PR DESCRIPTION
Permit LESSHISTFILE to be defined to "-" so it can be disabled at compile-time. From OpenBSD.

