### PR TITLE
Use estrdup() in save() instead of ecalloc()/strcpy()

### DIFF
--- a/main.c
+++ b/main.c
@@ -251,8 +251,8 @@ save(const char *s)
 {
 	char *p;
 
-	p = ecalloc(strlen(s)+1, sizeof (char));
-	(void) strcpy(p, s);
+	if ((p = estrdup(s)) == NULL)
+		quit(QUIT_ERROR);
 	return (p);
 }
 


### PR DESCRIPTION
Use estrdup() in save() instead of ecalloc()/strcpy().