### PR TITLE
Remove an unused variable in iread()

### DIFF
--- a/os.c
+++ b/os.c
@@ -37,7 +37,6 @@ int
 iread(int fd, unsigned char *buf, unsigned int len)
 {
 	int n;
-	sigset_t mask;
 
 start:
 	flush();


### PR DESCRIPTION
Exactly what it says on the tin.