### PR TITLE
Forbid "more -p h" or "less ++h"

### DIFF
--- a/command.c
+++ b/command.c
@@ -1394,6 +1394,13 @@ again:
 			 */
 			if (ch_getflags() & CH_HELPFILE)
 				break;
+			if (ungot != NULL || unget_end) {
+				error(less_is_more
+				    ? "Invalid option -p h"
+				    : "Invalid option ++h",
+				    NULL_PARG);
+				break;
+			}
 			cmd_exec();
 			save_hshift = hshift;
 			hshift = 0;


### PR DESCRIPTION
Do not allow h as part of -p (for more) or ++ (for less) because it will just end up in a loop (it is every_first_cmd, which is unget'ed for every new file). For example: less ++hq /etc/hosts

From OpenBSD, original commit message was:
````
----------------------------
revision 1.12
date: 2014/04/14 20:10:33;  author: schwarze;  state: Exp;  lines: +7 -0;
Deny requests to display interactive help unless we can be really sure
that they actually result from the user interactively asking for help.
Help requests originating from various other sources caused infinite loops.
OK millert@ "better than getting stuck in a help loop (sweet irony ;)" jmc@
----------------------------