### PR TITLE
Use time_t instead of long for time

### DIFF
--- a/funcs.h
+++ b/funcs.h
@@ -234,7 +234,6 @@ extern	void init_option(void);
 extern	struct loption *findopt(int);
 extern	struct loption *findopt_name(char **, char **, int *);
 extern	int iread(int, unsigned char *, unsigned int);
-extern	long get_time(void);
 extern	char *errno_message(char *);
 extern	int percentage(off_t, off_t);
 extern	off_t percent_pos(off_t, int, long);

--- a/linenum.c
+++ b/linenum.c
@@ -36,6 +36,7 @@
  */
 
 #include "less.h"
+#include <time.h>
 
 /*
  * Structure to keep track of a line number and the associated file position.
@@ -210,14 +211,14 @@ longloopmessage(void)
 }
 
 static int loopcount;
-static long startime;
+static time_t startime;
 
 static void
 longish(void)
 {
 	if (loopcount >= 0 && ++loopcount > 100) {
 		loopcount = 0;
-		if (get_time() >= startime + LONGTIME) {
+		if (time(NULL) >= startime + LONGTIME) {
 			longloopmessage();
 			loopcount = -1;
 		}
@@ -287,7 +288,7 @@ find_linenum(off_t pos)
 	 * The decision is based on which way involves
 	 * traversing fewer bytes in the file.
 	 */
-	startime = get_time();
+	startime = time(NULL);
 	if (p == &anchor || pos - p->prev->pos < p->pos - pos) {
 		/*
 		 * Go forward.

--- a/os.c
+++ b/os.c
@@ -25,7 +25,6 @@
 
 #include "less.h"
 #include <signal.h>
-#include <time.h>
 #include <errno.h>
 
 extern volatile sig_atomic_t sigs;
@@ -53,18 +52,6 @@ start:
 		return (-1);
 	}
 	return (n);
-}
-
-/*
- * Return the current time.
- */
-long
-get_time(void)
-{
-	time_t t;
-
-	(void) time(&t);
-	return (t);
 }
 
 /*


### PR DESCRIPTION
time(NULL) returns time_t which may not be long (it is int64_t on OpenBSD), so use time_t for "startime". Also remove an unnecessary wrapper function around time(NULL).
