### PR TITLE
Carefully handle '\0' in strchr arguments.

### DIFF
--- a/charset.c
+++ b/charset.c
@@ -245,7 +245,7 @@ checkfmt(const char *s)
 
 	if (*s == '*') {		/* skip leading attribute if there */
 		s++;
-		if (strchr("dksu", *s) == NULL) {
+		if (*s == '\0' || strchr("dksu", *s) == NULL) {
 			return (-1);
 		}
 		s++;
@@ -265,7 +265,8 @@ checkfmt(const char *s)
 		if (seen) {
 			return (-1);	/* 2nd % format item! */
 		}
-		while (strchr(" '+-0#", *s) != NULL) {	/* skip flags */
+		/* skip flags */
+		while (*s != '\0' && strchr(" '+-0#", *s) != NULL) {
 			s++;
 		}
 		while (isdigit(*s)) {			/* skip width */
@@ -286,7 +287,7 @@ checkfmt(const char *s)
 				s++;
 		}
 
-		if (strchr("cCdiouxX", *s) == NULL) {
+		if (*s == '\0' || strchr("cCdiouxX", *s) == NULL) {
 			/* bad or evil format character (%s, %n, etc.) */
 			return (-1);
 		}


### PR DESCRIPTION
The environment variable LESSBINFMT is not properly validated. If it is
set to "*", less will perform an out of boundary access.

This happens because strchr can be called with '\0' as second argument.
Such a call won't return NULL but the address of the '\0' in the string.
Therefore, the checkfmt function won't notice that the environment
variable is invalid.

The file line.c has the same issue but I'm not sure if '\0' is a valid
code in an ANSI sequence or not.