### PR TITLE
less.1: SECURE mode is not a compile-time option

### DIFF
--- a/less.1
+++ b/less.1
@@ -1589,8 +1589,6 @@ Metacharacters in filenames, such as "*".
 .It " "
 Filename completion (TAB, ^L).
 .El
-.Pp
-Less can also be compiled to be permanently in "secure" mode.
 .Sh COMPATIBILITY WITH MORE
 If the environment variable
 .Ev LESS_IS_MORE


### PR DESCRIPTION
from `CHANGES`:

```
SECURE mode (limited features) is removed - this version of less is always
fully featured.  (It was a compile-time option.)  Download official less
if you need restricted mode. (Hint: zones or chroot are better solutions!)
```