### PR TITLE
Remove macro aliases for wctype.h functions

### DIFF
--- a/cvt.c
+++ b/cvt.c
@@ -85,8 +85,8 @@ cvt_text(char *odst, char *osrc, int *chpos, int *lenp, int ops)
 					break;
 		} else {
 			/* Just copy the char to the destination buffer. */
-			if ((ops & CVT_TO_LC) && IS_UPPER(ch))
-				ch = TO_LOWER(ch);
+			if ((ops & CVT_TO_LC) && iswupper(ch))
+				ch = towlower(ch);
 			put_wchar(&dst, ch);
 			/* Record the original position of the char. */
 			if (chpos != NULL)

--- a/less.h
+++ b/less.h
@@ -38,17 +38,8 @@
  * (before options are parsed which might tell us what charset to use).
  */
 
-#undef IS_UPPER
-#undef IS_LOWER
-#undef TO_UPPER
-#undef TO_LOWER
 #undef IS_SPACE
 #undef IS_DIGIT
-
-#define	IS_UPPER(c)	iswupper(c)
-#define	IS_LOWER(c)	iswlower(c)
-#define	TO_UPPER(c)	towupper(c)
-#define	TO_LOWER(c)	towlower(c)
 
 #define	IS_SPACE(c)	isspace((unsigned char)(c))
 #define	IS_DIGIT(c)	isdigit((unsigned char)(c))


### PR DESCRIPTION
They're superfluous and barely used.