### PR TITLE
Pass errret to setupterm

### DIFF
--- a/screen.c
+++ b/screen.c
@@ -273,6 +273,7 @@ get_term(void)
 {
 	char *t1, *t2;
 	char *term;
+	int errret;
 
 	/*
 	 * Find out what kind of terminal this is.
@@ -281,8 +282,13 @@ get_term(void)
 		term = DEFAULT_TERM;
 	hardcopy = 0;
 
-	if (setupterm(term, 1, NULL) < 0) {
-		hardcopy = 1;
+	if (setupterm(term, 1, &errret) < 0) {
+		if (errret == 1) {
+			hardcopy = 1;
+		} else {
+			fprintf(stderr, "%s: unknown terminal type\n", term);
+			exit(1);
+		}
 	}
 	if (hard_copy == 1)
 		hardcopy = 1;


### PR DESCRIPTION
The setupterm(3) manual states:

> If errret is not null, then setupterm returns OK or ERR and stores a
> status value in the integer pointed to by errret.
> ...
> If errret is null, setupterm prints an error message upon finding an
> error and exits.

Since less(1) passes NULL, it will not return on error but instead
terminate the program.

Checking the returned value against ERR requires including curses.h
which causes a naming conflict with the existing beep function.
Therefore kept the condition as is.

The error message is borrowed from setupterm when errret is NULL and
does currently not distinguish between error code 0 and -1.