### PR TITLE
Plug memory leak

### DIFF
--- a/tags.c
+++ b/tags.c
@@ -97,6 +97,8 @@ cleantags(void)
 	 */
 	while ((tp = taglist.tl_first) != TAG_END) {
 		TAG_RM(tp);
+		free(tp->tag_file);
+		free(tp->tag_pattern);
 		free(tp);
 	}
 	curtag = NULL;


### PR DESCRIPTION
Make sure to free the copied strings while freeing tag entries.