### PR TITLE
Fix segfault on inverted search

### DIFF
--- a/pattern.c
+++ b/pattern.c
@@ -131,6 +131,8 @@ match_pattern(void *pattern, char *tpattern, char *line, int line_len,
 		rm.rm_so = 0;
 		rm.rm_eo = line_len;
 #endif
+		*sp = NULL;
+		*ep = NULL;
 		matched = !regexec(spattern, line, 1, &rm, flags);
 		if (matched) {
 			*sp = line + rm.rm_so;

--- a/search.c
+++ b/search.c
@@ -482,8 +482,6 @@ hilite_line(off_t linepos, char *line, int line_len, int *chpos,
 	char *searchp;
 	char *line_end = line + line_len;
 
-	if (sp == NULL || ep == NULL)
-		return;
 	/*
 	 * sp and ep delimit the first match in the line.
 	 * Mark the corresponding file positions, then
@@ -496,6 +494,9 @@ hilite_line(off_t linepos, char *line, int line_len, int *chpos,
 	 */
 	searchp = line;
 	do {
+		if (sp == NULL || ep == NULL)
+			return;
+
 		create_hilites(linepos, (intptr_t)sp - (intptr_t)line,
 		    (intptr_t)ep - (intptr_t)line, chpos);
 		/*


### PR DESCRIPTION
How to reproduce:

```sh
$ cat in
foo
bar
bar
$ less -g in # type: /!foo^J
```

When performing an inverted search in less, make sure to invalidate the
match bounds prior calling regexec(). In this inverted scenario a match
is found when regexec() returns false causing the bounds to not be
updated. This is problematic since the bounds will then refer to a
previous match and future pointer arithmetic will eventually be off
which is manifested in a SIGSEGV.

Issue reported by Larry Hynes on the OpenBSD tech mailing list[1].

[1] http://marc.info/?l=openbsd-tech&m=150114947021801&w=2